### PR TITLE
Add Doc interface for include_docs parameter

### DIFF
--- a/couch.go
+++ b/couch.go
@@ -160,6 +160,7 @@ type Row struct {
 	ID *string
 	Key interface{}
 	Value interface{}
+	Doc interface{}
 }
 
 type KeysRequest struct {


### PR DESCRIPTION
Hi,

Thanks for this useful lib. This adds the `Doc` field so that when querying a view with the include_docs field, the docs are now accessible view the `Doc` field. 

Often a views value is not the actual doc. Instead we can add the `include_doc = true` parameter to the view query to get the docs associated with the view.
